### PR TITLE
fix: ReportHelper: handle default job name when run via mocha

### DIFF
--- a/src/sdk/internal/helpers/reportHelper.ts
+++ b/src/sdk/internal/helpers/reportHelper.ts
@@ -90,8 +90,8 @@ export default class ReportHelper {
 
     let result = 'Unnamed Job';
 
-    const currentTestInfo = process.env.MOCHA_IT;
-    if (currentTestInfo) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    if (detectMocha()) {
       logger.debug('Attempting to infer job name using inspect.stack()');
       logger.debug("Inferred job name '{result}' from inspect.stack()");
       const callStackList = stackTraceGet();


### PR DESCRIPTION
If the user does not specified any job name,
And the test is running via mocha
the system will infer the job name.

Signed-off-by: Tom Shaffir <tom.shaffir@devalore.com>