### PR TITLE
fix: reporter: added the method disableAutoReports

### DIFF
--- a/src/sdk/internal/reporter/reporter.ts
+++ b/src/sdk/internal/reporter/reporter.ts
@@ -59,6 +59,8 @@ export default class Reporter {
    * @param {string} name - The test name
    * @param {boolean} passed - True(default) if the test should be marked as passed, False otherwise
    * @param {string} message - A message that goes with the test
+   *
+   * @returns {void}
    */
   public test(name?: string, passed = true, message?: string): void {
     if (!this.customCommandExecutor.disableReports) {
@@ -72,8 +74,20 @@ export default class Reporter {
           );
         }
       }
+
       const testReport = new CustomTestReport(testName, passed, message);
       this.customCommandExecutor.agentClient.reportTest(testReport);
     }
+  }
+
+  /**
+   * Disable auto reports, will disable/enable the automatic send of reports to the testproject platform
+   *
+   * @param {boolean} disabled - True to disable automatic commands reporting.
+   *
+   * @returns {void}
+   */
+  public disableAutoTestReports(disabled: boolean): void {
+    this.customCommandExecutor.disableAutoTestReports = disabled;
   }
 }


### PR DESCRIPTION
This method will let the user choose if he wants to report the tests
to testproject platform automatically.

Signed-off-by: Tom Shaffir <tom.shaffir@devalore.com>