### PR TITLE
fix: manualReporting: disable auto report on each test case

### DIFF
--- a/tests/examples/reports/manualReporting.spec.ts
+++ b/tests/examples/reports/manualReporting.spec.ts
@@ -31,6 +31,8 @@ describe('Test is reported as passed and failed with additional step', () => {
       .withToken(ConfigHelper.developerToken())
       .withCapabilities(Capabilities.chrome())
       .build();
+
+    driver.report().disableAutoTestReports(true);
   });
 
   afterEach(async () => {


### PR DESCRIPTION
On this test example we want to disable the automatic report of tests to 
testproject platform

Signed-off-by: Tom Shaffir tom.shaffir@devalore.com