### PR TITLE
Export mobile driver classes.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,9 @@
 import Builder from './sdk/drivers/webBuilder';
 import MobileBuilder from './sdk/drivers/mobileBuilder';
 import ThenableBaseDriver from './sdk/drivers/web/base/thenableBaseDriver';
+import AndroidDriver from './sdk/drivers/mobile/androidDriver';
+import IOSDriver from './sdk/drivers/mobile/iosDriver';
 
 export { ThenableBaseDriver };
 export { Builder, MobileBuilder };
+export { AndroidDriver, IOSDriver };


### PR DESCRIPTION
In order to create a mobile driver, the MobileBuilder class needs to be used.
For its creation it requires the driver type in order to use it to create a session. This means that these type must be exported in order to be used by the builder. This PR comes to add these missing exports.
This PR comes to fix #42 